### PR TITLE
fix: correct Docker container OS abstraction for NIEM Java tools

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -41,6 +41,12 @@ COPY --chown=appuser:appgroup api/third_party/niem-cmf /app/third_party/niem-cmf
 COPY --chown=appuser:appgroup api/third_party/niem-scheval /app/third_party/niem-scheval
 COPY --chown=appuser:appgroup api/third_party/niem-tran /app/third_party/niem-tran
 
+# Ensure shell scripts are executable (container is always Linux)
+RUN chmod +x /app/third_party/niem-cmf/cmftool-1.0/bin/cmftool && \
+    chmod +x /app/third_party/niem-scheval/scheval-1.0/bin/scheval && \
+    chmod +x /app/third_party/niem-tran/niemtran-1.0/bin/niemtran && \
+    find /app/third_party/niem-ndr -name "*.sh" -exec chmod +x {} \;
+
 # Create data directory and fix permissions
 RUN mkdir -p /data && chown appuser:appgroup /data
 RUN chown -R appuser:appgroup /app/src

--- a/api/src/niem_api/clients/cmf_client.py
+++ b/api/src/niem_api/clients/cmf_client.py
@@ -12,15 +12,11 @@ use the services/cmf_tool.py module.
 
 import logging
 import os
-import platform
 import subprocess
 from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
-
-# Detect platform for cross-platform compatibility
-IS_WINDOWS = platform.system() == "Windows"
 
 # CMF tool configuration
 # Check for environment variable first, then fall back to default path
@@ -33,8 +29,8 @@ if _CMF_PATH_ENV:
 else:
     # Default: Go up 4 levels from clients/cmf_client.py to get to api/ directory
     # File is at: api/src/niem_api/clients/cmf_client.py -> need 4 .parent to reach api/
-    # On Windows, use cmftool.bat; on Unix/Mac, use cmftool
-    _CMF_SCRIPT_NAME = "cmftool.bat" if IS_WINDOWS else "cmftool"
+    # In Docker, the container is always Linux, so always use the shell script (not .bat)
+    _CMF_SCRIPT_NAME = "cmftool"
     _CMF_DEFAULT_PATH = Path(__file__).parent.parent.parent.parent / f"third_party/niem-cmf/cmftool-1.0/bin/{_CMF_SCRIPT_NAME}"
 
     if _CMF_DEFAULT_PATH.exists():

--- a/api/src/niem_api/clients/niemtran_client.py
+++ b/api/src/niem_api/clients/niemtran_client.py
@@ -12,15 +12,11 @@ use the services/niemtran_service.py module.
 
 import logging
 import os
-import platform
 import subprocess
 from pathlib import Path
 from typing import Dict, Any, Optional
 
 logger = logging.getLogger(__name__)
-
-# Detect platform for cross-platform compatibility
-IS_WINDOWS = platform.system() == "Windows"
 
 # NIEMTran tool configuration
 # Check for environment variable first, then fall back to default path
@@ -33,8 +29,8 @@ if _NIEMTRAN_PATH_ENV:
 else:
     # Default: Go up 4 levels from clients/niemtran_client.py to get to api/ directory
     # File is at: api/src/niem_api/clients/niemtran_client.py -> need 4 .parent to reach api/
-    # On Windows, use niemtran.bat; on Unix/Mac, use niemtran
-    _NIEMTRAN_SCRIPT_NAME = "niemtran.bat" if IS_WINDOWS else "niemtran"
+    # In Docker, the container is always Linux, so always use the shell script (not .bat)
+    _NIEMTRAN_SCRIPT_NAME = "niemtran"
     _NIEMTRAN_DEFAULT_PATH = Path(__file__).parent.parent.parent.parent / f"third_party/niem-tran/niemtran-1.0/bin/{_NIEMTRAN_SCRIPT_NAME}"
 
     if _NIEMTRAN_DEFAULT_PATH.exists():

--- a/api/src/niem_api/clients/scheval_client.py
+++ b/api/src/niem_api/clients/scheval_client.py
@@ -12,16 +12,12 @@ For schematron validation business operations, use the services/domain/schema/sc
 import json
 import logging
 import os
-import platform
 import re
 import subprocess
 from pathlib import Path
 from typing import Dict, Any, Optional, List
 
 logger = logging.getLogger(__name__)
-
-# Detect platform for cross-platform compatibility
-IS_WINDOWS = platform.system() == "Windows"
 
 # Scheval tool configuration
 # Check for environment variable first, then fall back to default path
@@ -34,8 +30,8 @@ if _SCHEVAL_PATH_ENV:
 else:
     # Default: Go up 4 levels from clients/scheval_client.py to get to api/ directory
     # File is at: api/src/niem_api/clients/scheval_client.py -> need 4 .parent to reach api/
-    # On Windows, use scheval.bat; on Unix/Mac, use scheval
-    _SCHEVAL_SCRIPT_NAME = "scheval.bat" if IS_WINDOWS else "scheval"
+    # In Docker, the container is always Linux, so always use the shell script (not .bat)
+    _SCHEVAL_SCRIPT_NAME = "scheval"
     _SCHEVAL_DEFAULT_PATH = Path(__file__).parent.parent.parent.parent / f"third_party/niem-scheval/scheval-1.0/bin/{_SCHEVAL_SCRIPT_NAME}"
 
     if _SCHEVAL_DEFAULT_PATH.exists():


### PR DESCRIPTION
Removed incorrect platform detection that was checking the container OS instead of properly leveraging Docker's OS abstraction. The previous implementation attempted to detect Windows vs Linux/Mac from within the container, but platform.system() always returns "Linux" inside a Docker container regardless of the host OS.

Changes:
- Removed platform.system() detection from all Java tool clients
- Updated clients to always use shell scripts (not .bat files) since the container environment is always Linux
- Added chmod +x commands in Dockerfile to ensure scripts are executable regardless of host OS that checked out the git repository
- Added clarifying comments about Docker OS abstraction

This follows Docker best practices where the container defines the runtime environment independent of the host OS, enabling true "build once, run anywhere" portability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)