### PR TITLE
feat: make @context inclusion default in NIEM XML to JSON conversion

### DIFF
--- a/api/src/niem_api/handlers/convert.py
+++ b/api/src/niem_api/handlers/convert.py
@@ -142,12 +142,12 @@ async def _convert_single_file(
     schema_metadata: Dict[str, Any],
     cmf_content: str,
     schema_dir: str,
-    include_context: bool,
     context_uri: str
 ) -> Dict[str, Any]:
     """Convert a single XML file to JSON with error handling.
 
     This function is called concurrently for multiple files, controlled by semaphore.
+    The complete @context is always included in the conversion result.
 
     Args:
         file: Uploaded XML file
@@ -156,7 +156,6 @@ async def _convert_single_file(
         schema_metadata: Schema metadata
         cmf_content: CMF file content
         schema_dir: Path to schema directory for validation
-        include_context: Include complete @context
         context_uri: Optional context URI
 
     Returns:
@@ -208,7 +207,6 @@ async def _convert_single_file(
                 conversion_result = await niemtran_service.convert_xml_to_json(
                     xml_content=xml_content,
                     cmf_content=cmf_content,
-                    include_context=include_context,
                     context_uri=context_uri
                 )
 
@@ -258,7 +256,6 @@ async def handle_xml_to_json_batch(
     files: List[UploadFile],
     s3: Minio,
     schema_id: str = None,
-    include_context: bool = False,
     context_uri: str = None
 ) -> Dict[str, Any]:
     """
@@ -266,12 +263,12 @@ async def handle_xml_to_json_batch(
 
     Implements controlled concurrency as defined in ADR-001.
     Processes multiple files with semaphore-controlled parallelism.
+    The complete @context is always included in conversion results.
 
     Args:
         files: List of uploaded XML files
         s3: MinIO client
         schema_id: Optional schema ID (uses active schema if not provided)
-        include_context: Include complete @context in result
         context_uri: Optional URI to include as "@context:" URI pair
 
     Returns:
@@ -360,7 +357,7 @@ async def handle_xml_to_json_batch(
             asyncio.wait_for(
                 _convert_single_file(
                     file, s3, schema_id, schema_metadata, cmf_content,
-                    schema_dir, include_context, context_uri
+                    schema_dir, context_uri
                 ),
                 timeout=batch_config.OPERATION_TIMEOUT
             )

--- a/api/src/niem_api/main.py
+++ b/api/src/niem_api/main.py
@@ -279,7 +279,6 @@ async def convert_xml_to_json(
     files: List[UploadFile] = File(None),
     file: UploadFile = File(None),
     schema_id: str = Form(None),
-    include_context: bool = Form(False),
     context_uri: str = Form(None),
     token: str = Depends(verify_token),
     s3=Depends(get_s3_client)
@@ -289,6 +288,7 @@ async def convert_xml_to_json(
     Supports both single file and batch conversion.
     Uses the active schema's CMF model to perform the conversion.
     The resulting JSON follows NIEM JSON-LD conventions.
+    The complete @context is always included in conversion results.
 
     This is a utility tool for demo purposes - converted JSON is returned
     but not stored or ingested.
@@ -300,7 +300,6 @@ async def convert_xml_to_json(
         files: Multiple XML files to convert (for batch processing)
         file: Single XML file to convert (for backward compatibility)
         schema_id: Optional schema ID (uses active schema if not provided)
-        include_context: Include complete @context in the result
         context_uri: Optional URI to include as "@context:" URI pair
         token: Authentication token
         s3: MinIO client dependency
@@ -323,7 +322,7 @@ async def convert_xml_to_json(
             detail="No files provided. Please upload at least one XML file."
         )
 
-    return await handle_xml_to_json_batch(files, s3, schema_id, include_context, context_uri)
+    return await handle_xml_to_json_batch(files, s3, schema_id, context_uri)
 
 
 # Admin Routes

--- a/api/src/niem_api/services/niemtran_service.py
+++ b/api/src/niem_api/services/niemtran_service.py
@@ -24,7 +24,6 @@ logger = logging.getLogger(__name__)
 async def convert_xml_to_json(
     xml_content: bytes,
     cmf_content: str,
-    include_context: bool = False,
     context_uri: Optional[str] = None
 ) -> Dict[str, Any]:
     """
@@ -37,10 +36,11 @@ async def convert_xml_to_json(
     4. Cleaning up temporary files
     5. Error handling and reporting
 
+    The complete @context is always included in the conversion result.
+
     Args:
         xml_content: XML file content as bytes
         cmf_content: CMF model content as string
-        include_context: If True, include complete @context in result
         context_uri: Optional URI to include as "@context:" URI pair
 
     Returns:
@@ -75,10 +75,10 @@ async def convert_xml_to_json(
             # Build NIEMTran command
             cmd = ["x2j"]
 
-            # Add optional flags
-            if include_context:
-                cmd.append("--context")
+            # Always include complete @context
+            cmd.append("--context")
 
+            # Add optional context URI
             if context_uri:
                 cmd.extend(["--curi", context_uri])
 

--- a/ui/e2e/page-objects/XmlToJsonConverterPage.ts
+++ b/ui/e2e/page-objects/XmlToJsonConverterPage.ts
@@ -15,7 +15,6 @@ import path from 'path'
 export class XmlToJsonConverterPage extends BasePage {
   // Locators
   readonly schemaSelect: Locator
-  readonly includeContextCheckbox: Locator
   readonly fileInput: Locator
   readonly convertButton: Locator
   readonly removeAllButton: Locator
@@ -23,7 +22,6 @@ export class XmlToJsonConverterPage extends BasePage {
   constructor(page: Page) {
     super(page)
     this.schemaSelect = page.locator('select')
-    this.includeContextCheckbox = page.locator('input[type="checkbox"]#includeContext')
     this.fileInput = page.locator('input[type="file"]')
     this.convertButton = page.locator('button:has-text("Convert")')
     this.removeAllButton = page.locator('button:has-text("Remove All")')
@@ -60,16 +58,6 @@ export class XmlToJsonConverterPage extends BasePage {
 
     // Wait for files to appear in list
     await this.page.waitForTimeout(500)
-  }
-
-  /**
-   * Toggle the "Include complete @context" checkbox
-   */
-  async toggleIncludeContext(checked: boolean) {
-    const isChecked = await this.includeContextCheckbox.isChecked()
-    if (isChecked !== checked) {
-      await this.includeContextCheckbox.click()
-    }
   }
 
   /**

--- a/ui/e2e/tests/xml-to-json-converter.spec.ts
+++ b/ui/e2e/tests/xml-to-json-converter.spec.ts
@@ -137,26 +137,6 @@ test.describe('XML to JSON Converter', () => {
     const isEnabledAfterUpload = await converterPage.isConvertButtonDisabled()
     expect(isEnabledAfterUpload).toBeFalsy()
   })
-
-  test('E2E-306: Include context checkbox affects conversion', async ({ page }) => {
-    // ARRANGE: Upload XML file
-    await converterPage.uploadXmlFiles('valid-person.xml')
-
-    // ACT: Enable include context checkbox
-    await converterPage.toggleIncludeContext(true)
-
-    // ACT: Convert
-    await converterPage.clickConvert()
-    await converterPage.waitForConversionComplete()
-
-    // ASSERT: Conversion completes successfully
-    const stats = await converterPage.getConversionStats()
-    expect(stats.successful).toBe(1)
-
-    // Note: We're not testing the actual JSON content here,
-    // just that the conversion completes with the checkbox enabled.
-    // The backend should handle the @context inclusion.
-  })
 })
 
 /**

--- a/ui/src/components/ConversionResults.tsx
+++ b/ui/src/components/ConversionResults.tsx
@@ -109,14 +109,14 @@ export default function ConversionResults({ results }: ConversionResultsProps) {
                 {file.status === 'success' ? (
                   <>
                     <div className="text-sm text-gray-600">
-                      Converted successfully
+                      JSON file ready ({file.filename.replace('.xml', '.json')})
                     </div>
                     <button
                       onClick={() => downloadJson(file.filename, file.json_string!)}
                       className="inline-flex items-center px-2 py-1 border border-transparent text-xs font-medium rounded text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
                     >
                       <ArrowDownTrayIcon className="h-3 w-3 mr-1" />
-                      Download
+                      Download JSON
                     </button>
                   </>
                 ) : (

--- a/ui/src/components/XmlToJsonConverter.tsx
+++ b/ui/src/components/XmlToJsonConverter.tsx
@@ -9,7 +9,6 @@ export default function XmlToJsonConverter() {
   const [allSchemas, setAllSchemas] = useState<Schema[]>([]);
   const [selectedSchemaId, setSelectedSchemaId] = useState<string>('');
   const [files, setFiles] = useState<File[]>([]);
-  const [includeContext, setIncludeContext] = useState(false);
   const [converting, setConverting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [batchResult, setBatchResult] = useState<BatchConversionResult | null>(null);
@@ -75,8 +74,7 @@ export default function XmlToJsonConverter() {
 
       const result = await apiClient.convertXmlToJson(
         files,
-        selectedSchemaId || undefined,
-        includeContext
+        selectedSchemaId || undefined
       );
 
       setBatchResult(result);
@@ -141,19 +139,6 @@ export default function XmlToJsonConverter() {
                 </p>
               </div>
             )}
-          </div>
-
-          <div className="flex items-center">
-            <input
-              type="checkbox"
-              id="includeContext"
-              checked={includeContext}
-              onChange={(e) => setIncludeContext(e.target.checked)}
-              className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
-            />
-            <label htmlFor="includeContext" className="ml-2 block text-sm text-gray-900">
-              Include complete @context in result
-            </label>
           </div>
         </div>
       </div>

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -186,7 +186,6 @@ class ApiClient {
   async convertXmlToJson(
     files: File | File[],
     schemaId?: string,
-    includeContext: boolean = false,
     contextUri?: string
   ): Promise<BatchConversionResult> {
     const formData = new FormData();
@@ -200,7 +199,6 @@ class ApiClient {
     if (schemaId) {
       formData.append('schema_id', schemaId);
     }
-    formData.append('include_context', includeContext.toString());
     if (contextUri) {
       formData.append('context_uri', contextUri);
     }


### PR DESCRIPTION
## Summary
This PR makes the complete `@context` inclusion a default behavior in NIEM XML to JSON conversion, removing the UI option and simplifying the user experience.

## Changes Made

### Backend (API)
- **niemtran_service.py**: Removed `include_context` parameter and always add `--context` flag to NIEMTran command
- **convert.py**: Removed `include_context` from handler functions (`handle_xml_to_json_batch` and `_convert_single_file`)
- **main.py**: Removed `include_context` parameter from `/api/convert/xml-to-json` endpoint

### Frontend (UI)
- **XmlToJsonConverter.tsx**: Removed `includeContext` state and checkbox UI element
- **api.ts**: Removed `includeContext` parameter from `convertXmlToJson` method
- **ConversionResults.tsx**: Enhanced download UI to show JSON filename (e.g., "JSON file ready (example.json)") and button text "Download JSON"

### E2E Tests
- **XmlToJsonConverterPage.ts**: Removed `includeContextCheckbox` locator and `toggleIncludeContext` method
- **xml-to-json-converter.spec.ts**: Removed "E2E-306: Include context checkbox affects conversion" test

## Benefits
- ✅ Simplified user experience - no configuration needed
- ✅ Consistent output format - @context always included
- ✅ Clearer download UI - users know exactly what file they're getting
- ✅ Reduced code complexity - one less parameter to maintain

## Testing
- Rebuilt Docker containers with no cache
- All containers running successfully
- Verified changes across the full stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)